### PR TITLE
[Batch] 기존에 api에서 제공하는 이미지 url만 저장하는 것에서 S3로 저장하는 것으로 수정 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'io.prometheus:simpleclient_pushgateway:0.16.0'
+    implementation 'software.amazon.awssdk:s3:2.31.7'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/mopl/mopl_batch/batch/batch/tmdb/client/TmdbClient.java
+++ b/src/main/java/com/mopl/mopl_batch/batch/batch/tmdb/client/TmdbClient.java
@@ -31,6 +31,7 @@ public class TmdbClient {
 	private final Map<Integer, String> genres;
 	private final static long TOO_MANY_REQUESTS_EXCEPTION = 60_000L;
 	private final static long HTTP_SERVER_ERROR_EXCEPTION_SLEEP = 5_000L;
+	private final static String TMDB_IMAGE_BASE_URL = "https://image.tmdb.org/t/p/w500";
 
 	public TmdbClient(
 		@Qualifier("tmdbRestClient") RestClient sportsApiRestClient) {
@@ -117,7 +118,7 @@ public class TmdbClient {
 				.title(dto.getTitle())
 				.type(type)
 				.description(dto.getOverview())
-				.thumbnailUrl(dto.getPosterPath())
+				.thumbnailUrl(buildImageUrl(dto.getPosterPath()))
 				.sourceId(dto.getId())
 				.tags(new HashSet<>(tags))
 				.build());
@@ -156,7 +157,7 @@ public class TmdbClient {
 				.title(dto.getName())
 				.type(type)
 				.description(dto.getOverview())
-				.thumbnailUrl(dto.getPosterPath())
+				.thumbnailUrl(buildImageUrl(dto.getPosterPath()))
 				.sourceId(dto.getId())
 				.tags(new HashSet<>(tags))
 				.build());
@@ -190,6 +191,13 @@ public class TmdbClient {
 			Thread.currentThread().interrupt();
 			throw new IllegalStateException("Interrupted while retrying", ie);
 		}
+	}
+
+	private String buildImageUrl(String path) {
+		if (path == null || path.isBlank()) {
+			return null;
+		}
+		return TMDB_IMAGE_BASE_URL + path;
 	}
 
 }

--- a/src/main/java/com/mopl/mopl_batch/batch/config/JpaConfig.java
+++ b/src/main/java/com/mopl/mopl_batch/batch/config/JpaConfig.java
@@ -39,7 +39,7 @@ public class JpaConfig {
 		em.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
 
 		HashMap<String, Object> properties = new HashMap<>();
-		properties.put("hibernate.hbm2ddl.auto", "update");
+		properties.put("hibernate.hbm2ddl.auto", "create");
 		properties.put("hibernate.show_sql", "false");
 		properties.put("hibernate.physical_naming_strategy",
 			"org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy");

--- a/src/main/java/com/mopl/mopl_batch/batch/config/JpaConfig.java
+++ b/src/main/java/com/mopl/mopl_batch/batch/config/JpaConfig.java
@@ -39,7 +39,7 @@ public class JpaConfig {
 		em.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
 
 		HashMap<String, Object> properties = new HashMap<>();
-		properties.put("hibernate.hbm2ddl.auto", "validate");
+		properties.put("hibernate.hbm2ddl.auto", "update");
 		properties.put("hibernate.show_sql", "false");
 		properties.put("hibernate.physical_naming_strategy",
 			"org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy");

--- a/src/main/java/com/mopl/mopl_batch/batch/config/S3Config.java
+++ b/src/main/java/com/mopl/mopl_batch/batch/config/S3Config.java
@@ -1,0 +1,39 @@
+package com.mopl.mopl_batch.batch.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.Getter;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Getter
+@Configuration
+@ConditionalOnProperty(name = "storage.type", havingValue = "s3")
+public class S3Config {
+	@Value("${aws.accessKeyId}")
+	private String accessKey;
+
+	@Value("${aws.secretKey}")
+	private String secretKey;
+
+	@Value("${aws.region}")
+	private String region;
+
+	@Value("${aws.bucket}")
+	private String bucket;
+
+	@Bean
+	public S3Client s3Client() {
+		AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+		return S3Client.builder()
+			.region(Region.of(region))
+			.credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+			.build();
+	}
+}

--- a/src/main/java/com/mopl/mopl_batch/batch/storage/BinaryStorage.java
+++ b/src/main/java/com/mopl/mopl_batch/batch/storage/BinaryStorage.java
@@ -3,6 +3,8 @@ package com.mopl.mopl_batch.batch.storage;
 import java.io.InputStream;
 import java.util.UUID;
 
+import com.mopl.mopl_batch.batch.entity.Type;
+
 public interface BinaryStorage {
 	void put(UUID userId, byte[] data, String contentType);
 
@@ -11,4 +13,8 @@ public interface BinaryStorage {
 	Boolean exists(UUID userId);
 
 	String getUrl(UUID userId);
+
+	String putThumbnail(Type type, long sourceId, byte[] data, String contentType);
+
+	String getThumbnailUrl(Type type, long sourceId);
 }

--- a/src/main/java/com/mopl/mopl_batch/batch/storage/BinaryStorage.java
+++ b/src/main/java/com/mopl/mopl_batch/batch/storage/BinaryStorage.java
@@ -1,0 +1,14 @@
+package com.mopl.mopl_batch.batch.storage;
+
+import java.io.InputStream;
+import java.util.UUID;
+
+public interface BinaryStorage {
+	void put(UUID userId, byte[] data, String contentType);
+
+	InputStream get(UUID userId);
+
+	Boolean exists(UUID userId);
+
+	String getUrl(UUID userId);
+}

--- a/src/main/java/com/mopl/mopl_batch/batch/storage/S3BinaryStorage.java
+++ b/src/main/java/com/mopl/mopl_batch/batch/storage/S3BinaryStorage.java
@@ -7,6 +7,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import com.mopl.mopl_batch.batch.config.S3Config;
+import com.mopl.mopl_batch.batch.entity.Type;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -59,5 +60,27 @@ public class S3BinaryStorage implements BinaryStorage {
 		String key = PATH + "/" + userId;
 		return String.format("https://%s.s3.%s.amazonaws.com/%s",
 			config.getBucket(), config.getRegion(), key);
+	}
+
+	@Override
+	public String putThumbnail(Type type, long sourceId, byte[] data, String contentType) {
+		String key = buildThumbnailKey(type, sourceId);
+
+		s3.putObject(b -> b.bucket(config.getBucket())
+			.key(key)
+			.contentType(contentType), RequestBody.fromBytes(data));
+
+		return getThumbnailUrl(type, sourceId);
+	}
+
+	@Override
+	public String getThumbnailUrl(Type type, long sourceId) {
+		String key = buildThumbnailKey(type, sourceId);
+		return String.format("https://%s.s3.%s.amazonaws.com/%s",
+			config.getBucket(), config.getRegion(), key);
+	}
+
+	private String buildThumbnailKey(Type type, long sourceId) {
+		return PATH + type.name() + "/" + sourceId;
 	}
 }

--- a/src/main/java/com/mopl/mopl_batch/batch/storage/S3BinaryStorage.java
+++ b/src/main/java/com/mopl/mopl_batch/batch/storage/S3BinaryStorage.java
@@ -1,0 +1,63 @@
+package com.mopl.mopl_batch.batch.storage;
+
+import java.io.InputStream;
+import java.util.UUID;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import com.mopl.mopl_batch.batch.config.S3Config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "storage.type", havingValue = "s3")
+public class S3BinaryStorage implements BinaryStorage {
+
+	private final S3Config config;
+	private final S3Client s3;
+	private static final String PATH = "thumbnail/";
+
+	@Override
+	public void put(UUID userId, byte[] data, String contentType) {
+		String key = PATH + "/" +  userId;
+
+		s3.putObject(b -> b.bucket(config.getBucket())
+			.key(key)
+			.contentType(contentType), RequestBody.fromBytes(data));
+	}
+
+	@Override
+	public InputStream get(UUID userId) {
+		String key = PATH + "/" +  userId;
+
+		return s3.getObject(b -> b.bucket(config.getBucket())
+			.key(key));
+	}
+
+	@Override
+	public Boolean exists(UUID userId) {
+		String key = PATH + "/" +  userId;
+
+		HeadObjectRequest headObjectRequest = HeadObjectRequest.builder()
+			.bucket(config.getBucket())
+			.key(key)
+			.build();
+
+		s3.headObject(headObjectRequest);
+		return true;
+	}
+
+	@Override
+	public String getUrl(UUID userId) {
+		String key = PATH + "/" + userId;
+		return String.format("https://%s.s3.%s.amazonaws.com/%s",
+			config.getBucket(), config.getRegion(), key);
+	}
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,17 +2,17 @@ spring:
   datasource:
     jdbc-url: jdbc:postgresql://localhost:5432/batch
     driver-class-name: org.postgresql.Driver
-    username: postgres
+    username: app
     password: 1234
 
   batch:
     datasource:
       jdbc-url: jdbc:postgresql://localhost:5432/batch
       driver-class-name: org.postgresql.Driver
-      username: postgres
+      username: app
       password: 1234
-    jdbc:
-      initialize-schema: always
+#    jdbc:
+#      initialize-schema: always
     job:
       enabled: false
     schedule:
@@ -21,7 +21,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: create
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,3 +35,13 @@ management:
   metrics:
     tags:
       application: ${spring.application.name}
+
+
+aws:
+  accessKeyId: ${AWS_S3_ACCESS_KEY}
+  secretKey: ${AWS_S3_SECRET_KEY}
+  region: ${AWS_S3_REGION}
+  bucket: ${AWS_S3_BUCKET}
+
+storage:
+  type: s3


### PR DESCRIPTION
## PR 요약
api url -> s3 url로 수정 

## 체크리스트
- [x] 이 PR과 관련된 이슈가 있나요? (#11 )
- [x] 기능/버그 수정 테스트 완료
- [ ] 코드 리뷰 완료


## 상세 설명
초기 S3를 설정하는 코드와 Writer 단계에서 이미지를 다운로드(byte[]) 후 s3로 저장하는 것으로 수정
하나씩 저장하다보니 시간이 오래걸려 여러 스레드로 병렬로 처리하도록 수정 

## 검증 단계
Sport api, tmdb 둘 다 테스트를 진행하고 잘 저장됨을 확인
<img width="728" height="231" alt="image" src="https://github.com/user-attachments/assets/e072c1ca-0349-46e9-9834-1c318c9d68bb" />

<img width="1261" height="948" alt="image" src="https://github.com/user-attachments/assets/e5c5653b-615d-4aef-8154-8dc834a7441f" />



